### PR TITLE
chore(budgets): update build size thresholds in `angular.json`

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -39,13 +39,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "200kb",
+                  "maximumError": "400kb"
                 }
               ],
               "outputHashing": "all"


### PR DESCRIPTION
- Increased initial budget limits to 2MB (warning) and 5MB (error).
- Updated component style limits to 200KB (warning) and 400KB (error).
