### PR TITLE
Handles container fill level updates

### DIFF
--- a/src/pages/active-routes/model/store/active-routes.ts
+++ b/src/pages/active-routes/model/store/active-routes.ts
@@ -389,6 +389,24 @@ export const ActiveRoutesStore = signalStore(
         }));
 
         console.log(`📍 Ubicación actualizada para ruta ${routeId.substring(0, 8)}`);
+      },
+
+      updateContainerFillLevel(
+        containerId: string,
+        fillLevelPercentage: number
+      ): void {
+        patchState(store, (state) => ({
+          containers: state.containers.map(container =>
+            container.id === containerId
+              ? {
+                ...container,
+                currentFillLevel: fillLevelPercentage
+              }
+              : container
+          )
+        }));
+
+        console.log(`🗑️ Fill level actualizado para container ${containerId.substring(0, 8)}: ${fillLevelPercentage}%`);
       }
     };
   })

--- a/src/pages/active-routes/ui/active-routes/active-routes.page.ts
+++ b/src/pages/active-routes/ui/active-routes/active-routes.page.ts
@@ -12,7 +12,8 @@ import {EventBusService} from '../../../../shared/services/event-bus.service';
 import {
   RouteLocationUpdatedEvent,
   WebSocketConnectedEvent,
-  WebSocketDisconnectedEvent
+  WebSocketDisconnectedEvent,
+  ContainerUpdatedEvent
 } from '../../../../shared/models/websocket-events';
 import {TruckMarker} from '../../../../shared/helpers/truck-marker.helper';
 import {ToastService} from '../../../../shared/api/services/toast.service';
@@ -153,6 +154,11 @@ export class ActiveRoutesPage implements OnInit, OnDestroy {
       this.webSocketService.unsubscribeFromRouteLocation(route.id);
     });
 
+    const containers = this.getRouteContainers();
+    containers.forEach(container => {
+      this.webSocketService.unsubscribeFromContainerUpdateFillLevel(container.id);
+    });
+
     this.webSocketService.disconnect();
   }
 
@@ -161,6 +167,7 @@ export class ActiveRoutesPage implements OnInit, OnDestroy {
       //console.log('WebSocket conectado');
       this.toastService.success('Conectado al sistema de seguimiento en tiempo real');
       this.subscribeToAllActiveRoutes();
+      this.subscribeToAllContainers();
     });
 
     const disconnectedSub = this.eventBus.on(WebSocketDisconnectedEvent).subscribe(() => {
@@ -173,7 +180,12 @@ export class ActiveRoutesPage implements OnInit, OnDestroy {
       this.handleRouteLocationUpdate(event);
     });
 
-    this.subscriptions.push(connectedSub, disconnectedSub, locationSub);
+    const containerSub = this.eventBus.on(ContainerUpdatedEvent).subscribe(event => {
+      //console.log('Container fill level updated:', event.payload);
+      this.handleContainerFillLevelUpdate(event);
+    });
+
+    this.subscriptions.push(connectedSub, disconnectedSub, locationSub, containerSub);
   }
 
   private subscribeToAllActiveRoutes(): void {
@@ -186,6 +198,15 @@ export class ActiveRoutesPage implements OnInit, OnDestroy {
       if (route.currentLatitude && route.currentLongitude) {
         this.createTruckMarkerForRoute(route);
       }
+    });
+  }
+
+  private subscribeToAllContainers(): void {
+    const containers = this.getRouteContainers();
+    //console.log(`Suscribiendo a ${containers.length} containers...`);
+
+    containers.forEach(container => {
+      this.webSocketService.subscribeToContainerUpdateFillLevel(container.id);
     });
   }
 
@@ -212,6 +233,23 @@ export class ActiveRoutesPage implements OnInit, OnDestroy {
       this.toastService.success(
         `Ruta actualizada: ${remaining} punto${remaining !== 1 ? 's' : ''} restante${remaining !== 1 ? 's' : ''}`
       );
+    }
+  }
+
+  private handleContainerFillLevelUpdate(event: ContainerUpdatedEvent): void {
+    const { payload } = event;
+
+    this.store.updateContainerFillLevel(
+      payload.containerId,
+      payload.fillLevelPercentage
+    );
+
+    const cacheKey = `container-${payload.containerId}`;
+    this.markerContentCache.delete(cacheKey);
+
+    const container = this.store.getContainer()(payload.containerId);
+    if (container) {
+      this.getContainerMarkerContent(container);
     }
   }
 
@@ -420,6 +458,7 @@ export class ActiveRoutesPage implements OnInit, OnDestroy {
 
     if (this.wsStatus() === WebSocketConnectionStatus.CONNECTED) {
       this.subscribeToAllActiveRoutes();
+      this.subscribeToAllContainers();
     }
   }
 

--- a/src/shared/models/websocket-events.ts
+++ b/src/shared/models/websocket-events.ts
@@ -36,8 +36,22 @@ export class RouteLocationUpdatedEvent extends WebSocketEvent {
   }
 }
 
+export interface ContainerUpdatedFillLevelPayload {
+  containerId: string;
+  fillLevelPercentage: number;
+}
+
+export class ContainerUpdatedEvent extends WebSocketEvent {
+  readonly type = 'ContainerUpdated';
+
+  constructor(public readonly payload: ContainerUpdatedFillLevelPayload) {
+    super();
+  }
+}
+
 export type AppWebSocketEvent =
   | WebSocketConnectedEvent
   | WebSocketDisconnectedEvent
   | WebSocketErrorEvent
-  | RouteLocationUpdatedEvent;
+  | RouteLocationUpdatedEvent
+  | ContainerUpdatedEvent;

--- a/src/shared/services/websocket.service.ts
+++ b/src/shared/services/websocket.service.ts
@@ -7,7 +7,7 @@ import {
   WebSocketDisconnectedEvent,
   WebSocketErrorEvent,
   RouteLocationUpdatedEvent,
-  RouteCurrentLocationUpdatedPayload
+  RouteCurrentLocationUpdatedPayload, ContainerUpdatedFillLevelPayload, ContainerUpdatedEvent
 } from '../models/websocket-events';
 
 export enum WebSocketConnectionStatus {
@@ -163,6 +163,75 @@ export class WebSocketService {
       //console.log('[WebSocket] RouteLocationUpdatedEvent emitted');
     } catch (error) {
       console.error('[WebSocket] Error handling route location update:', error);
+      this.eventBus.emit(new WebSocketErrorEvent(String(error)));
+    }
+  }
+
+  subscribeToContainerUpdateFillLevel(containerId: string): void {
+    if (this.status !== WebSocketConnectionStatus.CONNECTED) {
+      console.warn('[WebSocket] Cannot subscribe, not connected');
+      return;
+    }
+
+    const destination = `/topic/containers/${containerId}/fill-level`;
+    const subscriptionKey = `container_fill_level_${containerId}`;
+
+    if (this.subscriptions.has(subscriptionKey)) {
+      console.log('[WebSocket] Already subscribed to:', destination);
+      return;
+    }
+
+    try {
+      const subscription = this.client!.subscribe(
+        destination,
+        (message: IMessage) => {
+          console.log('[WebSocket]  RAW MESSAGE RECEIVED on', destination);
+          console.log('[WebSocket]  Message headers:', message.headers);
+          console.log('[WebSocket]  Message body:', message.body);
+          this.handleContainerFillLevelUpdate(message);
+        }
+      );
+
+      this.subscriptions.set(subscriptionKey, subscription);
+      console.log('[WebSocket] Successfully subscribed to:', destination);
+      console.log('[WebSocket] Total active subscriptions:', this.subscriptions.size);
+    } catch (error) {
+      console.error('[WebSocket] Error subscribing:', error);
+      this.eventBus.emit(new WebSocketErrorEvent(String(error)));
+    }
+  }
+
+  unsubscribeFromContainerUpdateFillLevel(containerId: string): void {
+    const subscriptionKey = `container_fill_level_${containerId}`;
+    const subscription = this.subscriptions.get(subscriptionKey);
+
+    if (subscription) {
+      subscription.unsubscribe();
+      this.subscriptions.delete(subscriptionKey);
+      console.log('[WebSocket] Unsubscribed from container fill level:', containerId);
+    }
+  }
+
+  private handleContainerFillLevelUpdate(message: IMessage): void {
+    try {
+      //console.log('[WebSocket] 🗑️ Container fill level update received');
+      //console.log('[WebSocket] Message body:', message.body);
+
+      if (!message.body) {
+        console.warn('[WebSocket] Message body is empty');
+        return;
+      }
+
+      const payload: ContainerUpdatedFillLevelPayload = JSON.parse(message.body);
+      //console.log('[WebSocket] Parsed payload:', payload);
+
+      // Emitir evento al EventBus
+      const event = new ContainerUpdatedEvent(payload);
+      this.eventBus.emit(event);
+
+
+    } catch (error) {
+      console.error('[WebSocket] Error handling container fill level update:', error);
       this.eventBus.emit(new WebSocketErrorEvent(String(error)));
     }
   }


### PR DESCRIPTION
Adds functionality to handle updates to container fill levels via WebSocket events. This allows the application to receive and display real-time information about how full containers are.

- Subscribes to container update events upon WebSocket connection
- Updates the container's fill level in the store when a `ContainerUpdatedEvent` is received
- Updates the UI to reflect the new fill level

The branch name is "feature/handle-container-updated-fill-level".